### PR TITLE
ci: use git commit hash for deployments

### DIFF
--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -22,7 +22,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.18.2
+      ref: refs/tags/release/3.20.0
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -22,7 +22,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.18.2
+      ref: refs/tags/release/3.20.0
   pipelines:
     - pipeline: build
       source: Build
@@ -30,10 +30,6 @@ resources:
         branches:
           include:
             - main
-        paths:
-          exclude:
-          - infrastructure
-          - packer
 
 extends:
   template: stages/wrapper_cd.yml@templates
@@ -46,11 +42,12 @@ extends:
         deploymentJobs:
           - name: Deploy App
             steps:
-              - template: ../steps/azure_web_app_deploy.yml
+              - template: ../steps/azure_web_app_deploy_slot.yml
                 parameters:
                   appName: pins-app-template-web-$(ENVIRONMENT)
                   appResourceGroup: $(resourceGroup)
                   azurecrName: $(azurecrName)
                   repository: devops/template
+                  slot: default
     globalVariables:
       - template: azure-pipelines-variables.yml@self

--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -1,20 +1,5 @@
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    exclude:
-      - infrastructure
-      - packer
-
-trigger:
-  branches:
-    include:
-      - app
-  paths:
-    exclude:
-      - infrastructure
-      - packer
+pr: none
+trigger: none
 
 resources:
   repositories:


### PR DESCRIPTION
## Describe your changes
Switch to newer versions of the Build & Deploy pipelines, to use git commit hash for docker image tags
NOTE: this does not change the release pipeline

More [docs here](https://pins-ds.atlassian.net/wiki/spaces/CS/pages/1719861253/App+Service+Deployments)

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/DEV-337)